### PR TITLE
Fix QC incorrect column order

### DIFF
--- a/code/data_processing/cc_qc.py
+++ b/code/data_processing/cc_qc.py
@@ -86,7 +86,17 @@ class CCqC():
             CATEGORY = 2
             print(f"FOR TASK SWITCHING -> Average accuracy at or below 0.5 across conditions and CATEGORY set to 2")
 
-        problematic_conditions = QC_UTILS.cond_block_not_reported(raw, self.ACC_COLUMN_NAME, self.COND_COLUMN_NAME, self.INCORRECT_SYMBOL)
+        # Check for blocks/conditions where every response is either incorrect
+        # or not reported. The first argument expects the column that defines
+        # the blocks/conditions and the second is the accuracy column. The
+        # previous implementation mistakenly flipped these arguments which
+        # caused the check to operate on the wrong columns.
+        problematic_conditions = QC_UTILS.cond_block_not_reported(
+            raw,
+            self.COND_COLUMN_NAME,
+            self.ACC_COLUMN_NAME,
+            self.INCORRECT_SYMBOL,
+        )
 
         if len(problematic_conditions) != 0:
             CATEGORY = 3

--- a/code/data_processing/mem_qc.py
+++ b/code/data_processing/mem_qc.py
@@ -68,7 +68,15 @@ class MEM_QC:
                 print(f"Condition/Block '{condition}' has accuracy == 0% and CATEGORY set to 3")
         avg_acc /= len(accuracy)
 
-        problematic_conditions = QC_UTILS.cond_block_not_reported(raw, self.ACC_COLUMN_NAME, self.COND_COLUMN_NAME, self.INCORRECT_SYMBOL)
+        # Detect any blocks/conditions where all responses are incorrect or
+        # missing. The utility expects the condition column first followed by
+        # the accuracy column; previously these were reversed.
+        problematic_conditions = QC_UTILS.cond_block_not_reported(
+            raw,
+            self.COND_COLUMN_NAME,
+            self.ACC_COLUMN_NAME,
+            self.INCORRECT_SYMBOL,
+        )
 
         if len(problematic_conditions) != 0:
             CATEGORY = 3

--- a/code/data_processing/ps_qc.py
+++ b/code/data_processing/ps_qc.py
@@ -90,7 +90,14 @@ class PS_QC:
             CATEGORY = 2
             print(f"FOR DSST -> Average accuracy at or below 0.5 across conditions and CATEGORY set to 2")
 
-        problematic_conditions = QC_UTILS.cond_block_not_reported(raw, self.ACC_COLUMN_NAME, self.COND_COLUMN_NAME, self.INCORRECT_SYMBOL)
+        # Identify blocks/conditions with only incorrect or missing responses.
+        # Arguments were previously inverted, leading to incorrect detection.
+        problematic_conditions = QC_UTILS.cond_block_not_reported(
+            raw,
+            self.COND_COLUMN_NAME,
+            self.ACC_COLUMN_NAME,
+            self.INCORRECT_SYMBOL,
+        )
 
         if len(problematic_conditions) != 0:
             CATEGORY = 3


### PR DESCRIPTION
## Summary
- correct argument order when checking for missing blocks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850204f2a1083219f8ad646485cbddd